### PR TITLE
Add link handler. Refs #10

### DIFF
--- a/js/onload.js
+++ b/js/onload.js
@@ -21,3 +21,4 @@ var onWebviewReady = function() {
 getWebview().addEventListener('did-finish-load', onWebviewReady);
 getWebview().addEventListener("dom-ready", onWebviewReady);
 getWebview().addEventListener("did-navigate-in-page", checkEnableShareButton);
+getWebview().addEventListener("new-window", handleExternalLinkClick);

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,3 +1,4 @@
+const {shell} = require('electron');
 const remote = require('electron').remote;
 window.jq = require('./js/jquery-3.1.0.min.js');
 
@@ -45,5 +46,12 @@ var checkEnableShareButton = function(e){
     jq("#share").removeClass("disabled");
   }else{
     jq("#share").addClass("disabled");
+  }
+}
+
+var handleExternalLinkClick = function(e){
+  const protocol = require('url').parse(e.url).protocol;
+  if(protocol === 'http:' || protocol === 'https:'){
+    shell.openExternal(e.url);
   }
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,5 +1,4 @@
-const {shell} = require('electron');
-const remote = require('electron').remote;
+const {shell, remote} = require('electron');
 window.jq = require('./js/jquery-3.1.0.min.js');
 
 window.setCustomTheme = function(theme){


### PR DESCRIPTION
This pull request adds a handleExternalLinkClick function that checks the protocol of the clicked link, and if the link is a variant of HTTP, it opens the link in a new browser.

Side note: I wasn't thrilled with my implementation on [line 1 of utils.js](https://github.com/JakeC1020/wunderlistux/blob/master/js/utils.js#L1) as it has duplicate calls to `require('electron')`. I originally tried to do something along the lines of:
```javascript
const {shell} = require('electron');
const remote = shell.remote;
```
However, electron did not seem happy with this. I am fairly new to electron, but maybe you know a way to write what is currently being implemented while reducing the calls to `require('electron')`?