### PR TITLE
added check for running the script in a terminal

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# Test for a terminal!
+fd=0   # stdin
+#  As we recall, the -t test option checks whether the stdin, [ -t 0 ],
+#+ or stdout, [ -t 1 ], in a given script is running in a terminal.
+if [ -t "$fd" ]
+then
+  echo 'Starting install of wunderlistux...' 2>&1
+else
+  echo 'You need to run the installer in a terminal!' 2>&1
+  zenity --info --text="Please open a terminal and run the install script with this command:\n sudo ./install.sh"
+  exit 1
+fi
+
 ARCH=`uname -m`
 KERNEL=`uname -s`
 


### PR DESCRIPTION
For users, they are unfamiliar with using the terminal, they may be running the script with a double click from the file browser. In this case, the users get no response of the error. With this piece of code, a zenity box informs the users.